### PR TITLE
NP-274 Add scenario for Journal types

### DIFF
--- a/26-register_publication/274-creator_navigates_to_the_reference_tab_and_selects_contribution_to_journal.feature
+++ b/26-register_publication/274-creator_navigates_to_the_reference_tab_and_selects_contribution_to_journal.feature
@@ -1,0 +1,23 @@
+Feature: Creator navigates to the Reference tab and selects Contribution to Journal
+
+  @274
+  Scenario: Creator navigates to the Reference tab and selects Contribution to Journal
+    Given that the Creator opens their Publication and navigates to the Reference tab
+    When they select Contribution to Journal as Reference Type
+    And they see a dropdown of potential Reference Subtypes consisting of:
+      | Journal article      |
+      | Short communication  |
+      | Letter to the Editor |
+      | Book review          |
+      | Editoral             |
+      | Corrigendum          |
+    And they see mandatory fields for:
+      | Search-box for Journal |
+    And they see optional fields for:
+      | Volume         |
+      | Issue          |
+      | Pages from     |
+      | Pages to       |
+      | Article number |
+    And they see a disabled field with DOI if the Publication has a DOI
+    And they see a optional field for Peer-review if Journal article is selected as Reference Subtype

--- a/mvp.feature
+++ b/mvp.feature
@@ -231,28 +231,6 @@ Feature: MVP features for NVA
     And they see Next is enabled
     And they see Save is enabled
 
-  @274
-  Scenario: Creator navigates to Reference tab and selects Publication in Journal
-    Given Creator begins registering a Publication in the Wizard
-    When they navigate to the Reference tab
-    And they select a Reference Type — Publication in Journal
-    And they can select a Publication Subtype from the list
-      | Article              |
-      | Short communication  |
-      | Leader               |
-      | Letter to the editor |
-      | Review               |
-    Then they see the Search box for "Journal title" #this needs to be tested for mandatory-ness
-    And they see fields for
-      | DOI            |
-      | Volume         |
-      | Issue          |
-      | Pages from     |
-      | Pages to       |
-      | Article number |
-    And they see a preselected value for Peer review "Not peer reviewed" #also mandatory
-    And they see the NVI evaluation is Not NVI Applicable
-
   @392
   Scenario Outline: Creator navigates to the Reference tab and selects Book
     Given Creator begins registering a Publication in the Wizard


### PR DESCRIPTION
Fjernet det som omhandler Summary Page, siden det heller hører til en egen story
```
    And they view the Summary Page
    Then they see that the information is registered
```