### PR TITLE
Add related registrations to landing page

### DIFF
--- a/1228-public_page/anonymous_user_views_landing_page_for_registration.feature
+++ b/1228-public_page/anonymous_user_views_landing_page_for_registration.feature
@@ -17,4 +17,5 @@ Feature: Anonymous User views Landing Page for Registration
             | Contributors                    |
             | Files                           |
             | DOI link                        |
+            | Related registrations           |
             | License                         |

--- a/1228-public_page/anonymous_user_views_landing_page_for_registration.feature
+++ b/1228-public_page/anonymous_user_views_landing_page_for_registration.feature
@@ -17,5 +17,5 @@ Feature: Anonymous User views Landing Page for Registration
             | Contributors                    |
             | Files                           |
             | DOI link                        |
-            | Related registrations           |
+            | Related Registrations           |
             | License                         |


### PR DESCRIPTION
Hvis registreringen ikke har noen relaterte registreringer skal denne sikkert ikke vises, så mulig dette blir litt for enkelt?
Ser for meg at Landing Page burde deles opp i ganske mange scenario (gjerne en per type e.l.)