### PR TITLE
chore: Copy scenarios from other sources

### DIFF
--- a/nvi/nvi-access-control.feature
+++ b/nvi/nvi-access-control.feature
@@ -1,0 +1,8 @@
+# Copied from https://sikt.atlassian.net/wiki/spaces/NVAP/pages/3323461700/Access+control
+Feature: Access control
+  Scenario: NVI curator can access their own candidates
+    Given a logged in user
+    And the user is part of an NVI institution
+    And the user have access right(s) to handle NVI candidates
+    And the user has a area of responsibility*
+    Then the user should only access candidates with at least one verified contributor affiliated to the users area of responsibitily

--- a/nvi/nvi-approval-process.feature
+++ b/nvi/nvi-approval-process.feature
@@ -1,0 +1,52 @@
+# Copied from https://sikt.atlassian.net/wiki/spaces/NVAP/pages/3322904645/NVI+Approval+process
+Feature: NVI approval process
+
+  Scenario: NVI curator approves Candidate
+    Given a logged in user
+    And the user is part of an NVI institution
+    And the user have access right(s) to handle NVI candidates
+    And the user has selected a specific NVI candidate
+    Then the user can approve the NVA candidate on behalf of his/hers institution
+
+  Scenario: NVI curator rejects Candidate
+    Given a logged in user
+    And the user is part of an NVI institution
+    And the user have access right(s) to handle NVI candidates
+    And the user has selected a specific NVI candidate
+    Then the user can reject the NVA candidate on behalf of his/hers institution with a rejection note
+
+  Scenario: NVI curator resets approval status
+    Given a logged in curator with access right(s) to handle NVI candidates
+    And views an approved NVI candidate in an active NVI periode
+    When the approval is removed
+    Then the approval status is set back to Pending
+
+  Scenario: NVI curator resets rejection status with note
+    Given a logged in curator with access right(s) to handle NVI candidates
+    And views an rejected NVI candidate in an active NVI periode
+    When the rejection is removed
+    Then the approval status is set back to Pending
+    And the rejection note that followed the rejection is removed
+
+  # *candidate-affecting fields are changed:
+  # level, publication type (category), creators with affiliations, points and year
+  Scenario: Reset NVI Candidate on change
+    Given an NVI candidate
+    When one or more of the candidate-affecting fields are changed
+    And the NVI candidate is still a candidate
+    Then reset the approval status for all involved institutions for the NVI candidate.
+    And the points should be updated according to the new factors.
+
+  Scenario: NVI curator adds note to Candidate
+    Given a logged in user
+    And the user is part of an NVI institution
+    And the user have access right(s) to handle NVI candidates
+    And the user has selected a specific NVI candidate
+    Then the user can add a note to the candidate
+    And the note is visible for all nvi-curators with access right to view the candidate
+
+  Scenario: Mark disputes
+    Given a nvi candidate
+    When the candidate has more than one approval
+    And at least two institutions disagree on whether the candidate should be approved or rejected (one approved approval and one rejected approval)
+    Then the candidate has global approval status “Dispute”

--- a/nvi/nvi-candidacy-requirements.feature
+++ b/nvi/nvi-candidacy-requirements.feature
@@ -1,0 +1,60 @@
+Feature: Requirements for NVI candidacy
+
+  # Glossary:
+  # NVI: Norwegian Scientific Index
+  # NVI Candidate: A publication that meets the criteria to be included in the NVI
+  # Creator: A contributor with a significant role in the creation of the publication, i.e. author
+  # NVI Customer: An institution or organization that is part of the NVI system
+  # Active year: The current year in which the publication is being evaluated
+  # Publication channel: The medium through which the publication is disseminated (e.g., journal, conference)
+  # Scientific level: A rating that indicates the quality and impact of the publication channel
+  # Identified contributor: Contributor that has a Cristin ID and is verified in Cristin
+
+
+  # Copied from https://sikt.atlassian.net/browse/NP-44705
+  Scenario Outline: A publication is identified as an NVI candidate
+    Given a logged in user with sufficient access rights
+    And login is associated with a customer that is an "NVI institution"
+    And there is a publication where at least one identified contributor with role Creator is affiliated with the login context customer
+    And the publication is of <Type>
+    And the publication is published in the active year
+    And the publication has at least one publication channel of type <Channel> that has a level of one or two
+    When the user views the NVI candidates
+    Then the user sees the publication
+
+    Examples:
+      | Type                     | Channel   |
+      | AcademicArticle          | journal   |
+      | AcademicChapter          | publisher |
+      | AcademicChapter          | series    |
+      | AcademicLiteratureReview | journal   |
+      | AcademicMonograph        | publisher |
+      | AcademicMonograph        | series    |
+
+  # Copied from https://sikt.atlassian.net/browse/NP-45122
+  Scenario: Detect new NVI Candidate
+    Given a publication
+    And all criteria for being an NVA candidate is fulfilled
+    When the publication is published
+    Then the publication become an NVI candidate for the corresponding NVA period.
+
+
+  # Copied from https://sikt.atlassian.net/browse/NP-45115
+  Scenario: Remove NVI Candidate on change
+    Given an NVI candidate
+    When one or more of the candidate-affecting fields are changed
+    And the NVI candidate is no longer an NVI candidate
+    Then remove the NVI candidate from the NVI candidate list.
+
+  # Copied from https://sikt.atlassian.net/browse/NP-47998
+  Scenario Outline:
+    Given a publication of type Academic Commentary with at least one identified* contributor with role Creator is affiliated with a nvi customer*
+    And the publication is published in the active year
+    And the publication has at least one publication channel of type <Channel> that has a scientific level of one or two
+    And the publication is not reported as a candidate in previous years
+    Then the publication is identified as a NVI candidate
+
+    Examples:
+      | Channel   |
+      | publisher |
+      | series    |

--- a/nvi/nvi-point-calculation.feature
+++ b/nvi/nvi-point-calculation.feature
@@ -1,0 +1,1 @@
+# TODO: Create Gherkin scenarios from https://sikt.atlassian.net/wiki/spaces/NVAP/pages/2847703136/NVI+Point+calculation+rules

--- a/nvi/nvi-reporting.feature
+++ b/nvi/nvi-reporting.feature
@@ -1,4 +1,6 @@
 # Copied from https://sikt.atlassian.net/browse/NP-48230
+
+@NotImplemented
 Feature: NVI reporting
 
   Scenario: Self-report completion of "NVI Control and Approval"

--- a/nvi/nvi-reporting.feature
+++ b/nvi/nvi-reporting.feature
@@ -1,0 +1,61 @@
+# Copied from https://sikt.atlassian.net/browse/NP-48230
+Feature: NVI reporting
+
+  Scenario: Self-report completion of "NVI Control and Approval"
+    Given an NVI period is open,
+    And all NVI candidates are resolved,
+    When an Editor checks the <status> of the NVI period,
+    And the status of their institution is displayed,
+    Then the Editor can mark the "NVI Control and Approval" as "Done" for its institustion.
+
+    Examples:
+      | status             |
+      | Departments        |
+      | Candidate          |
+      | Being checked      |
+      | Approved           |
+      | Rejected           |
+      | Total number       |
+      | Publication points |
+      | Dispute            |
+
+  Scenario: A System Administrator checks the status of the NVI period
+    Given an NVI period is open,
+    When a System Administrator inspects the NVI period,
+    And the <status> of each participating institution is displayed,
+    And it is clearly indicated which institutions have marked their status as "Done,"
+    Then the System Administrator can choose to close the NVI period.
+
+    Examples:
+      | status             |
+      | Institution        |
+      | Candidate          |
+      | Being checked      |
+      | Approved           |
+      | Rejected           |
+      | Total number       |
+      | Publication points |
+      | Dispute            |
+      | Done               |
+
+  Scenario: A NVI period is closed
+    Given an NVI period is open,
+    When a System Administrator closes the NVI period,
+    Then all NVI Control and Approval actions are disabled for institutions,
+    And institutions can view the status of the registrations and the period,
+    And the NVI period is marked as "closed" in the system.
+
+  Scenario: NVI reported results are marked
+    Given "A NVI period is closed",
+    When a System Administrator closes the NVI period,
+    Then all approved results in this period are marked as "NVI reported,"
+    And secure copies of each result are stored for future reference.
+
+  Scenario: The reported results are compiled into a published dataset
+    Given "NVI reported results are marked",
+    When a System Administrator closes the NVI period,
+    Then descriptive metadata for all "NVI reported" results is compiled into a dataset,
+    And a schema describing the dataset syntax is added as a seperate file,
+    And the dataset is published in NVA by Sikt,
+    And a publishing file request is created,
+    And a DOI request is created.

--- a/nvi/nvi-workflow-change.feature
+++ b/nvi/nvi-workflow-change.feature
@@ -1,0 +1,103 @@
+Feature: Changing values in a NVI-candidate
+
+    # @test
+    Scenario Outline: Contributor changes from unidentified to identified
+        Given a curator opens a Result that is a NVI-candidate with an unidentified contributor
+        And the Result is "<Source>" registration
+        And the Result is "<Collaboration>"
+        When the curator changes a contributor from unidentified to identified
+        And saves the changes
+        Then the Result is a NVI-candidate
+
+        Examples:
+            | Source | Collaboration                      |
+            | Manual | no Collaboration                   |
+            | Import | no Collaboration                   |
+            | Manual | NVI institution Collaboration      |
+            | Import | NVI institution Collaboration      |
+            | Manual | NVA institution Collaboration      |
+            | Import | NVA institution Collaboration      |
+            | Manual | external institution Collaboration |
+            | Import | external institution Collaboration |
+
+    # @test
+    Scenario Outline: Category changes from non-scientific to scientific
+        Given a curator opens a non-scientific Result that is a NVI-candidate
+        And the Result is "<Source>" registration
+        And the Result is "<Collaboration>"
+        When the curator changes the Category from non-scientific to scientific
+        And saves the changes
+        Then the Result is a NVI-candidate
+
+        Examples:
+            | Source | Collaboration                      |
+            | Manual | no Collaboration                   |
+            | Import | no Collaboration                   |
+            | Manual | NVI institution Collaboration      |
+            | Import | NVI institution Collaboration      |
+            | Manual | NVA institution Collaboration      |
+            | Import | NVA institution Collaboration      |
+            | Manual | external institution Collaboration |
+            | Import | external institution Collaboration |
+
+    # @test
+    Scenario Outline: Category changes from scientific to non-scientific
+        Given a curator opens a scientific Result that is a NVI-candidate
+        And the Result is "<Source>" registration
+        And the Result is "<Collaboration>"
+        When the curator changes the Category from scientific to non-scientific
+        And saves the changes
+        Then the Result is not a NVI-candidate
+
+        Examples:
+            | Source | Collaboration                      |
+            | Manual | no Collaboration                   |
+            | Import | no Collaboration                   |
+            | Manual | NVI institution Collaboration      |
+            | Import | NVI institution Collaboration      |
+            | Manual | NVA institution Collaboration      |
+            | Import | NVA institution Collaboration      |
+            | Manual | external institution Collaboration |
+            | Import | external institution Collaboration |
+
+    # @test
+    Scenario Outline: Category changes from non-scientific to scientific, contributor changes from unidentified to identified
+        Given a curator opens a non-scientific Result that is a NVI-candidate with unidentified contributor
+        And the Result is "<Source>" registration
+        And the Result is "<Collaboration>"
+        When the curator changes the Category from non-scientific to scientific
+        And the curator changes a contributor from unidentified to identified
+        And saves the changes
+        Then the Result is a NVI-candidate
+
+        Examples:
+            | Source | Collaboration                      |
+            | Manual | no Collaboration                   |
+            | Import | no Collaboration                   |
+            | Manual | NVI institution Collaboration      |
+            | Import | NVI institution Collaboration      |
+            | Manual | NVA institution Collaboration      |
+            | Import | NVA institution Collaboration      |
+            | Manual | external institution Collaboration |
+            | Import | external institution Collaboration |
+
+    # @test
+    Scenario Outline: Category changes from scientific to non-scientific, contributor changes from unidentified to identified
+        Given a curator opens a scientific Result that is a NVI-candidate with unidentified contributor
+        And the Result is "<Source>" registration
+        And the Result is "<Collaboration>"
+        When the curator changes the Category from scientific to non-scientific
+        And the curator changes a contributor from unidentified to identified
+        And saves the changes
+        Then the Result is not a NVI-candidate
+
+        Examples:
+            | Source | Collaboration                      |
+            | Manual | no Collaboration                   |
+            | Import | no Collaboration                   |
+            | Manual | NVI institution Collaboration      |
+            | Import | NVI institution Collaboration      |
+            | Manual | NVA institution Collaboration      |
+            | Import | NVA institution Collaboration      |
+            | Manual | external institution Collaboration |
+            | Import | external institution Collaboration |

--- a/nvi/nvi-workflow-contributor.feature
+++ b/nvi/nvi-workflow-contributor.feature
@@ -1,0 +1,33 @@
+Feature: NVI workflow - contributor
+
+    # @test
+    Scenario Outline: Publication NVI status - contributor
+        Given a Curator views the NVI-tasklist
+        When a Publication is a "<Category>"
+        And the Publication has status "<PublicationStatus>"
+        And the Publication is collaborating with "<IsCollaboration>"
+        And the Publication is "<TypeOfRegistration>"
+        Then the Publication has NVI status "<IsNviPublication>"
+
+        Examples:
+            | Category           | PublicationStatus | IsCollaboration      | TypeOfRegistration  | IsNviPublication    |
+            | Scientific Article | Published         | No one               | Manual Registration | NVI Publication     |
+            | Scientific Article | Published         | No one               | Import              | NVI Publication     |
+            | Scientific Article | Draft             | No one               | Manual Registration | Not NVI Publication |
+            | Scientific Article | Unpublished       | No one               | Manual Registration | Not NVI Publication |
+            | Scientific Article | Unpublished       | No one               | Import              | Not NVI Publication |
+            | Scientific Article | Published         | NVI-institution      | Manual Registration | NVI Publication     |
+            | Scientific Article | Published         | NVI-institution      | Import              | NVI Publication     |
+            | Scientific Article | Draft             | NVI-institution      | Manual Registration | Not NVI Publication |
+            | Scientific Article | Unpublished       | NVI-institution      | Manual Registration | Not NVI Publication |
+            | Scientific Article | Unpublished       | NVI-institution      | Import              | Not NVI Publication |
+            | Scientific Article | Published         | NVA-institution      | Manual Registration | NVI Publication     |
+            | Scientific Article | Published         | NVA-institution      | Import              | NVI Publication     |
+            | Scientific Article | Draft             | NVA-institution      | Manual Registration | Not NVI Publication |
+            | Scientific Article | Unpublished       | NVA-institution      | Manual Registration | Not NVI Publication |
+            | Scientific Article | Unpublished       | NVA-institution      | Import              | Not NVI Publication |
+            | Scientific Article | Published         | external institution | Manual Registration | NVI Publication     |
+            | Scientific Article | Published         | external institution | Import              | NVI Publication     |
+            | Scientific Article | Draft             | external institution | Manual Registration | Not NVI Publication |
+            | Scientific Article | Unpublished       | external institution | Manual Registration | Not NVI Publication |
+            | Scientific Article | Unpublished       | external institution | Import              | Not NVI Publication |

--- a/nvi/nvi-workflow-unidentified-contributor.feature
+++ b/nvi/nvi-workflow-unidentified-contributor.feature
@@ -1,0 +1,60 @@
+Feature: NVI-candidates with unidentified users
+
+  # @test
+  Scenario Outline: Identify publication as NVI candidate
+    Given a publication of "<Type>" published in the active period
+    And the publication has at least one publication channel of type "<Channel>" with scientific level of one or two
+    And the publication has at least one Author affiliated with an NVI institution
+    And the publication is not previously reported
+    Then the publication is identified as an NVI candidate
+
+    Examples:
+      | Type                     | Channel   |
+      | AcademicArticle          | journal   |
+      | AcademicChapter          | publisher |
+      | AcademicChapter          | series    |
+      | AcademicLiteratureReview | journal   |
+      | AcademicMonograph        | publisher |
+      | AcademicMonograph        | series    |
+      | AcademicCommentary       | publisher |
+      | AcademicCommentary       | series    |
+
+#     Scenario: Institution can approve/reject when all their contributors are identified
+#         Given a publication identified as an NVI candidate
+#         And Institution A is an NVI institution
+#         And all Authors affiliated with Institution A are identified
+#         Then Institution A can approve or reject the candidate
+
+#     Scenario: Institution cannot approve/reject when they have any non-identified contributors
+#         Given a publication identified as an NVI candidate
+#         And Institution A is an NVI institution
+#         And Institution A has at least one non-identified Author
+#         Then Institution A cannot approve or reject the candidate
+
+#     Scenario: NVI points per institution include only identified contributors
+#         Given a publication identified as an NVI candidate
+#         And Institution A is an NVI institution
+#         And Institution A has both identified and non-identified Authors
+#         Then the calculated NVI points for Institution A will include the shares of their identified contributors
+#         And will not include the shares of their non-identified contributors
+
+#     Scenario: NVI points are recalculated when the number of identified contributors changes
+#         Given a publication identified as an NVI candidate
+#         And Institutions A and B are NVI institutions
+#         And Institution B has at least one identified Author
+#         When the number of identified Authors affiliated with Institution A changes
+#         Then the NVI points for Institution A are recalculated accordingly
+#         And the NVI points for Institution B remain unchanged
+#     Scenario: Handle deadlocks when period closes
+#         Given a publication identified as an NVI candidate
+#         And Institutions A and B are NVI institutions
+#         And all Authors affiliated with Institution A are identified
+#         And Institution B has at least one unidentified Author
+#         When the active period closes and NVI points are reported
+#         Then Institution A is awarded NVI-points
+#         And Institution B is not awarded NVI-points
+# # The current implementation in Cristin requires the removal of the Institution B
+# # affiliation before Institution A can be awarded NVI points. However, this approach
+# # is not desired in the NVA implementation. The affiliation with Institution B is
+# # likely correct, but it has not yet been verified.
+# # It must be clearly visible on the front end that Institution B did not receive NVI points.

--- a/nvi/nvi-workflow-user.feature
+++ b/nvi/nvi-workflow-user.feature
@@ -1,0 +1,34 @@
+Feature: NVI workflow - user
+
+
+    # @test
+    Scenario Outline: Publication NVI status - user
+        Given a Curator views the NVI-tasklist
+        When a Publication is a "<Category>"
+        And the Publication has status "<PublicationStatus>"
+        And the Publication is collaborating with "<IsCollaboration>"
+        And the Publication is "<TypeOfRegistration>"
+        Then the Publication has NVI status "<IsNviPublication>"
+
+        Examples:
+            | Category           | PublicationStatus | IsCollaboration      | TypeOfRegistration  | IsNviPublication    |
+            | Scientific Article | Published         | No one               | Manual Registration | NVI Publication     |
+            | Scientific Article | Published         | No one               | Import              | NVI Publication     |
+            | Scientific Article | Draft             | No one               | Manual Registration | Not NVI Publication |
+            | Scientific Article | Unpublished       | No one               | Manual Registration | Not NVI Publication |
+            | Scientific Article | Unpublished       | No one               | Import              | Not NVI Publication |
+            | Scientific Article | Published         | NVI-institution      | Manual Registration | NVI Publication     |
+            | Scientific Article | Published         | NVI-institution      | Import              | NVI Publication     |
+            | Scientific Article | Draft             | NVI-institution      | Manual Registration | Not NVI Publication |
+            | Scientific Article | Unpublished       | NVI-institution      | Manual Registration | Not NVI Publication |
+            | Scientific Article | Unpublished       | NVI-institution      | Import              | Not NVI Publication |
+            | Scientific Article | Published         | NVA-institution      | Manual Registration | NVI Publication     |
+            | Scientific Article | Published         | NVA-institution      | Import              | NVI Publication     |
+            | Scientific Article | Draft             | NVA-institution      | Manual Registration | Not NVI Publication |
+            | Scientific Article | Unpublished       | NVA-institution      | Manual Registration | Not NVI Publication |
+            | Scientific Article | Unpublished       | NVA-institution      | Import              | Not NVI Publication |
+            | Scientific Article | Published         | external institution | Manual Registration | NVI Publication     |
+            | Scientific Article | Published         | external institution | Import              | NVI Publication     |
+            | Scientific Article | Draft             | external institution | Manual Registration | Not NVI Publication |
+            | Scientific Article | Unpublished       | external institution | Manual Registration | Not NVI Publication |
+            | Scientific Article | Unpublished       | external institution | Import              | Not NVI Publication |


### PR DESCRIPTION
Adds various NVI scenarios gathered from the E2E repository, Confluence, and Jira tasks.
This is done with minimal changes added for clarity and syntax validation.
The goal is to consolidate known/current rules in a single centralized location.