### PR TITLE
Np 48502 channel ownership

### DIFF
--- a/channel_ownership/channel_claims.feature
+++ b/channel_ownership/channel_claims.feature
@@ -1,7 +1,7 @@
 Feature: Channel claims
 
-  Scenario: Already claimed channel cannot be claimed
-    When a channel is claimed by institution A
+  Scenario: Owned channel cannot be claimed
+    When a channel is owned by institution A
     Then the channel cannot be claimed by insitution B
 
   Scenario: Editor can claim a channel for their institution
@@ -17,12 +17,14 @@ Feature: Channel claims
     Then an Editor at institution B cannot abandon the channel claim
 
   Scenario: Non-editor cannot claim a channel
-    When a user is not Editor
-    Then they cannot claim a channel
+    Given a user is not Editor
+    When they inspect an unclaimed channel
+    Then they cannot claim it
 
   Scenario: Non-editor cannot abandon claim of a channel
-    When a user is not Editor
-    Then they cannot abandon a channel claim
+    Given a user is not Editor
+    When they inspect a claimed channel
+    Then they cannot abandon the claim
 
   Scenario: View all channel claims
     When requesting all channel claims

--- a/channel_ownership/channel_claims.feature
+++ b/channel_ownership/channel_claims.feature
@@ -13,20 +13,20 @@ Feature: Channel claims
     Then the channel is claimed by the users institution
 
   Scenario: Editor can abandon claim of a channel for their own institution
-    Given a user logge in as Editor
+    Given a user logged in as Editor
     And a channel claimed by their institution
     When the channel claim us abandoned by the user
     Then the channel is unclaimed
 
   Scenario: Editor cannot claim a channel on behalf of another institution
-    Given a user logge in as Editor
+    Given a user logged in as Editor
     And an unclaimed channel
     When the user claims the channel on behalf of another institution
     Then they are denied
     And the channel is still unclaimed
 
   Scenario: Editor cannot abandon claim of a channel on behalf of another institution
-    Given a user logge in as Editor
+    Given a user logged in as Editor
     And a channel claimed by another institution
     When the channel claim us abandoned by the user
     Then they are denied

--- a/channel_ownership/channel_claims.feature
+++ b/channel_ownership/channel_claims.feature
@@ -1,0 +1,67 @@
+Feature: Channel claims
+
+  Scenario: No one can claim an already claimed channel
+    Given any user
+    And a claimed channel
+    When the user claims the channel
+    Then they are denied
+
+  Scenario: Editor can claim a channel for their own institution
+    Given a user logged in as Editor
+    And an unclaimed channel
+    When the user claims the channel
+    Then the channel is claimed by the users institution
+
+  Scenario: Editor can abandon claim of a channel for their own institution
+    Given a user logge in as Editor
+    And a channel claimed by their institution
+    When the channel claim us abandoned by the user
+    Then the channel is unclaimed
+
+  Scenario: Editor cannot claim a channel on behalf of another institution
+    Given a user logge in as Editor
+    And an unclaimed channel
+    When the user claims the channel on behalf of another institution
+    Then they are denied
+    And the channel is still unclaimed
+
+  Scenario: Editor cannot abandon claim of a channel on behalf of another institution
+    Given a user logge in as Editor
+    And a channel claimed by another institution
+    When the channel claim us abandoned by the user
+    Then they are denied
+    And the channel is still claimed by the other institution
+
+  Scenario: Non-editor cannot claim a channel
+    Given a user not logged in as Editor
+    And an unclaimed channel
+    When the user claims the channel
+    Then they are denied
+    And the channel is still unclaimed
+
+  Scenario: Non-editor cannot abandon claim of a channel
+    Given a user not logged in as Editor
+    And a claimed channel
+    When the channel claim is abandoned by the user
+    Then they are denied
+    And the channel is still claimed
+
+  Scenario: Logged in user can view all channel claims
+    Given a logged in user
+    When they request all channel claims
+    Then all channel claims are returned
+
+  Scenario: Anonymous user cannot view channel claims
+    Given an anonumous user
+    When they request all channel claims
+    Then no channel claims are returned
+
+  Scenario: Logged in user can filter channels claimed by institution
+    Given a logged in user
+    When they request all channel claims filtered by an institution
+    Then all channels claimed by that institution are returned
+
+  Scenario: No one can view channels not claimed
+    Given any user
+    When they request all channels not claimed
+    Then they are denied

--- a/channel_ownership/channel_claims.feature
+++ b/channel_ownership/channel_claims.feature
@@ -4,7 +4,7 @@ Feature: Channel claims
     Given any user
     And a claimed channel
     When the user claims the channel
-    Then they are denied
+    Then the channel is still unclaimed
 
   Scenario: Editor can claim a channel for their own institution
     Given a user logged in as Editor
@@ -15,36 +15,32 @@ Feature: Channel claims
   Scenario: Editor can abandon claim of a channel for their own institution
     Given a user logged in as Editor
     And a channel claimed by their institution
-    When the channel claim us abandoned by the user
+    When the channel claim is abandoned by the user
     Then the channel is unclaimed
 
   Scenario: Editor cannot claim a channel on behalf of another institution
     Given a user logged in as Editor
     And an unclaimed channel
     When the user claims the channel on behalf of another institution
-    Then they are denied
-    And the channel is still unclaimed
+    Then the channel is still unclaimed
 
   Scenario: Editor cannot abandon claim of a channel on behalf of another institution
     Given a user logged in as Editor
     And a channel claimed by another institution
-    When the channel claim us abandoned by the user
-    Then they are denied
-    And the channel is still claimed by the other institution
+    When the channel claim is abandoned by the user
+    Then the channel is still claimed by the other institution
 
   Scenario: Non-editor cannot claim a channel
     Given a user not logged in as Editor
     And an unclaimed channel
     When the user claims the channel
-    Then they are denied
-    And the channel is still unclaimed
+    Then the channel is still unclaimed
 
   Scenario: Non-editor cannot abandon claim of a channel
     Given a user not logged in as Editor
     And a claimed channel
     When the channel claim is abandoned by the user
-    Then they are denied
-    And the channel is still claimed
+    Then the channel is still claimed
 
   Scenario: View all channel claims
     When requesting all channel claims

--- a/channel_ownership/channel_claims.feature
+++ b/channel_ownership/channel_claims.feature
@@ -1,46 +1,28 @@
 Feature: Channel claims
 
-  Scenario: No one can claim an already claimed channel
-    Given any user
-    And a claimed channel
-    When the user claims the channel
-    Then the channel is still unclaimed
+  Scenario: Already claimed channel cannot be claimed
+    When a channel is claimed by institution A
+    Then the channel cannot be claimed by insitution B
 
-  Scenario: Editor can claim a channel for their own institution
-    Given a user logged in as Editor
-    And an unclaimed channel
-    When the user claims the channel
-    Then the channel is claimed by the users institution
+  Scenario: Editor can claim a channel for their institution
+    When an Editor claims a channel
+    Then the channel is owned by the Editors institution
 
-  Scenario: Editor can abandon claim of a channel for their own institution
-    Given a user logged in as Editor
-    And a channel claimed by their institution
-    When the channel claim is abandoned by the user
-    Then the channel is unclaimed
+  Scenario: Editor can abandon claim of a channel for their institution
+    When an Editor at institution A claims a channel
+    Then an Editor at institution A can abandon the channel claim
 
-  Scenario: Editor cannot claim a channel on behalf of another institution
-    Given a user logged in as Editor
-    And an unclaimed channel
-    When the user claims the channel on behalf of another institution
-    Then the channel is still unclaimed
-
-  Scenario: Editor cannot abandon claim of a channel on behalf of another institution
-    Given a user logged in as Editor
-    And a channel claimed by another institution
-    When the channel claim is abandoned by the user
-    Then the channel is still claimed by the other institution
+  Scenario: Editor cannot abandon claim of a channel owned by another institution
+    When an Editor at institution A claims a channel
+    Then an Editor at institution B cannot abandon the channel claim
 
   Scenario: Non-editor cannot claim a channel
-    Given a user not logged in as Editor
-    And an unclaimed channel
-    When the user claims the channel
-    Then the channel is still unclaimed
+    When a user is not Editor
+    Then they cannot claim a channel
 
   Scenario: Non-editor cannot abandon claim of a channel
-    Given a user not logged in as Editor
-    And a claimed channel
-    When the channel claim is abandoned by the user
-    Then the channel is still claimed
+    When a user is not Editor
+    Then they cannot abandon a channel claim
 
   Scenario: View all channel claims
     When requesting all channel claims

--- a/channel_ownership/channel_claims.feature
+++ b/channel_ownership/channel_claims.feature
@@ -50,6 +50,6 @@ Feature: Channel claims
     When requesting all channel claims
     Then all channel claims are returned
 
-  Scenario: Filter channels claimed by institution
+  Scenario: Filter channel claims by institution
     When requesting all channel claims, with a filter by institution
     Then all channels claimed by that institution are returned

--- a/channel_ownership/channel_claims.feature
+++ b/channel_ownership/channel_claims.feature
@@ -46,22 +46,10 @@ Feature: Channel claims
     Then they are denied
     And the channel is still claimed
 
-  Scenario: Logged in user can view all channel claims
-    Given a logged in user
-    When they request all channel claims
+  Scenario: View all channel claims
+    When requesting all channel claims
     Then all channel claims are returned
 
-  Scenario: Anonymous user cannot view channel claims
-    Given an anonumous user
-    When they request all channel claims
-    Then no channel claims are returned
-
-  Scenario: Logged in user can filter channels claimed by institution
-    Given a logged in user
-    When they request all channel claims filtered by an institution
+  Scenario: Filter channels claimed by institution
+    When requesting all channel claims, with a filter by institution
     Then all channels claimed by that institution are returned
-
-  Scenario: No one can view channels not claimed
-    Given any user
-    When they request all channels not claimed
-    Then they are denied

--- a/channel_ownership/channel_constraints.feature
+++ b/channel_ownership/channel_constraints.feature
@@ -43,14 +43,7 @@ Feature: Channel constraints
     When the user edits constraints on the channel
     Then they are denied
 
-  Scenario: Logged in user can view constraints for any claimed channel
-    Given a logged in user
-    And a channel claim
-    When they request the channel claim constraints
+  Scenario: View constraints for any claimed channel
+    Given a channel claim
+    When the channel claim constraints are requested
     Then the channel claim constraints are returned
-
-  Scenario: Anonymous user cannot view constraints for claimed channel
-    Given an anonymous user
-    And a channel claim
-    When they request the channel claim constraints
-    Then no constraints are returned

--- a/channel_ownership/channel_constraints.feature
+++ b/channel_ownership/channel_constraints.feature
@@ -1,0 +1,56 @@
+Feature: Channel constraints
+
+  Scenario: Default constraints when claiming a channel
+    Given a user logged in as Editor
+    When a channel is claimed
+    Then the policy for registering metadata is set to allow-all
+    And the policy for editing metadata after file is published is set to allow-all
+    And the scope is set to DegreePhd, DegreeMaster, and DegreeBachelor
+
+  @ignore(not_part_of_first_delivery)
+  Scenario: Editor can set channel constraints when claiming a channel
+    Given user logged in as Editor
+    When claiming a channel
+    And policy for who can register metadata is set
+    And policy for who can edit metadata after file is published is set
+    And scope of the constraints is set
+    Then the channel is claimed with these constraints
+
+  @ignore(not_part_of_first_delivery)
+  Scenario: Editor can edit constraints on a channel claimed by their institution
+    Given a user logged in as Editor
+    And a channel claimed by their institution
+    When the policy for who can register metadata is updated
+    And the policy for who can edit metadata after file is published is updated
+    And the scope of the constraints are updated
+    Then the constraints of the channel claim are updated
+
+  Scenario: Editor cannot edit constraints on a channel not claimed
+    Given a user logged in as Editor
+    And an unclaimed channel
+    When the user edits constraints on the channel
+    Then they are denied
+
+  Scenario: Editor cannot edit constraints on a channel claimed by another institution
+    Given a user logged in as Editor
+    And a channel claimed by another institution
+    When the user edits constraints on the channel
+    Then they are denied
+
+  Scenario: Non-editor cannot edit channel constraints
+    Given a user not logged in as Editor
+    And a channel claim
+    When the user edits constraints on the channel
+    Then they are denied
+
+  Scenario: Logged in user can view constraints for any claimed channel
+    Given a logged in user
+    And a channel claim
+    When they request the channel claim constraints
+    Then the channel claim constraints are returned
+
+  Scenario: Anonymous user cannot view constraints for claimed channel
+    Given an anonymous user
+    And a channel claim
+    When they request the channel claim constraints
+    Then no constraints are returned

--- a/channel_ownership/channel_constraints.feature
+++ b/channel_ownership/channel_constraints.feature
@@ -1,49 +1,48 @@
 Feature: Channel constraints
 
   Scenario: Default constraints when claiming a channel
-    Given a user logged in as Editor
     When a channel is claimed
     Then the policy for registering metadata is set to allow-all
     And the policy for editing metadata after file is published is set to allow-all
     And the scope is set to DegreePhd, DegreeMaster, and DegreeBachelor
 
   @ignore(not_part_of_first_delivery)
-  Scenario: Editor can set channel constraints when claiming a channel
-    Given user logged in as Editor
-    When claiming a channel
-    And policy for who can register metadata is set
-    And policy for who can edit metadata after file is published is set
-    And scope of the constraints is set
-    Then the channel is claimed with these constraints
+  Scenario Outline: Editor can edit channel constraints when claiming a channel
+    When an Editor claims a channel
+    Then they have the option to edit <Constraint>
+
+    Examples:
+      | Constraint                                    |
+      | Who can register metadata                     |
+      | Who can edit metadata after file is published |
+      | The scope of the constraints                  |
 
   @ignore(not_part_of_first_delivery)
-  Scenario: Editor can edit constraints on a channel claimed by their institution
-    Given a user logged in as Editor
-    And a channel claimed by their institution
-    When the policy for who can register metadata is updated
-    And the policy for who can edit metadata after file is published is updated
-    And the scope of the constraints are updated
-    Then the constraints of the channel claim are updated
+  Scenario Outline: Editor can edit constraints on a channel owned by their institution
+    When an Editor edits a channel owned by their institution
+    Then they have the option to edit <Constraint>
 
-  Scenario: Editor cannot edit constraints on a channel not claimed
-    Given a user logged in as Editor
-    And an unclaimed channel
-    When the user edits constraints on the channel
-    Then they are denied
+    Examples:
+      | Constraint                                    |
+      | Who can register metadata                     |
+      | Who can edit metadata after file is published |
+      | The scope of the constraints                  |
 
-  Scenario: Editor cannot edit constraints on a channel claimed by another institution
-    Given a user logged in as Editor
-    And a channel claimed by another institution
-    When the user edits constraints on the channel
-    Then they are denied
+  Scenario: Editor cannot edit constraints on a channel owned by another institution
+    When an Editor at institution A claims a channel
+    Then an Editor at institution B cannot edit the constraints of that channel claim
 
-  Scenario: Non-editor cannot edit channel constraints
-    Given a user not logged in as Editor
-    And a channel claim
-    When the user edits constraints on the channel
-    Then they are denied
+  Scenario Outline: Non-editor cannot edit channel constraints
+    Given a user is not Editor
+    When they inspect a channel claim
+    Then they don not have the option to edit <Constraint>
 
-  Scenario: View constraints for any claimed channel
-    Given a channel claim
-    When the channel claim constraints are requested
-    Then the channel claim constraints are returned
+    Examples:
+      | Constraint                                    |
+      | Who can register metadata                     |
+      | Who can edit metadata after file is published |
+      | The scope of the constraints                  |
+
+  Scenario: View constraints for a claimed channel
+    When requesting the constraints of a channel claim
+    Then the constraints of the channel claim are returned

--- a/channel_ownership/channel_ownership_enforced.feature
+++ b/channel_ownership/channel_ownership_enforced.feature
@@ -1,51 +1,44 @@
 Feature: Channel ownership enforced
 
   Scenario Outline: An unclaimed channel should not have constraints
-    Given a user is Registrator
-    And they select an unclaimed channel
-    When they <Action>
-    Then they are allowed
+    When a Registrator selects an unclaimed channel
+    Then they have the option to <Action>
 
     Examples:
       | Action                                |
       | Register metadata                     |
       | Edit metadata after file is published |
 
-  Scenario Outline: Claimed channel with allow-all policy
-    Given a user is Registrator
-    And they select a channel claimed by <Channel claimed by>
-    And the selected channel has an allow-all policy on <Action>
-    And they select a Publication Instance Type <Instance Type included in scope> in the channel claim scope
-    When they register metadata
-    Then they are <Permission>
+  Scenario Outline: Claimed channel with allow-all policy for registering metadata
+    Given a channel X owned by institution A
+    And the channel claim has an allow-all policy on registering metadata
+    And the channel claim has scope DegreePhd, DegreeMaster, and DegreeBachelor
+    When a Registrator from <Institution> selects category <Instance type>
+    And selects channel X as publisher
+    Then the Registrator have the option to register the metadata
 
     Examples:
-      | Action                                | Channel claimed by  | Instance Type included in scope | Permission |
-      | Register metadata                     | Own institution     | Included                        | Allowed    |
-      | Register metadata                     | Own institution     | Not included                    | Allowed    |
-      | Register metadata                     | Another institution | Included                        | Allowed    |
-      | Register metadata                     | Another institution | Not included                    | Allowed    |
-      | Edit metadata after file is published | Own institution     | Included                        | Allowed    |
-      | Edit metadata after file is published | Own institution     | Not included                    | Allowed    |
-      | Edit metadata after file is published | Another institution | Included                        | Allowed    |
-      | Edit metadata after file is published | Another institution | Not included                    | Allowed    |
+      | Institution   | Instance type |
+      | Institution A | DegreePhd     |
+      | Institution A | Anthology     |
+      | Institution B | DegreePhd     |
+      | Institution B | Anthology     |
+
+  Scenario Outline: Claimed channel with deny-others policy for editing metadata after file is published
+    Given a channel X owned by institution A
+    And the channel claim has an deny-others policy on editing metadata after file is published
+    And the channel claim has scope DegreePhd, DegreeMaster, and DegreeBachelor
+    And a publication Y registered by a Registrator from institution A
+    And publication Y has category <Instance type>
+    And publication Y has contributor from institution B
+    And channel X is the publisher of publication Y
+    When a file on publication Y is published
+    Then only Curators from <Institutions> have the option to edit the metadata
+
+    Examples:
+      | Institutions                    | Instance type |
+      | Institution A                   | DegreePhd     |
+      | Institution A and Institution B | Anthology     |
 
   @ignore(not_part_of_first_delivery)
-  Scenario Outline: Claimed channel with deny-others policy
-    Given a user is Registrator
-    And they select a channel claimed by <Channel claimed by>
-    And the selected channel has a deny-others policy on <Action>
-    And they select a Publication Instance Type <Instance Type included in scope> in the channel claim scope
-    When they register metadata
-    Then they are <Permission>
-
-    Examples:
-      | Action                                | Channel claimed by  | Instance Type included in scope | Permission |
-      | Register metadata                     | Own institution     | Included                        | Allowed    |
-      | Register metadata                     | Own institution     | Not included                    | Allowed    |
-      | Register metadata                     | Another institution | Included                        | Denied     |
-      | Register metadata                     | Another institution | Not included                    | Allowed    |
-      | Edit metadata after file is published | Own institution     | Included                        | Allowed    |
-      | Edit metadata after file is published | Own institution     | Not included                    | Allowed    |
-      | Edit metadata after file is published | Another institution | Included                        | Denied     |
-      | Edit metadata after file is published | Another institution | Not included                    | Allowed    |
+  Scenario: Claimed channel with deny-others for registering and allow-all for editing metadata after file is published

--- a/channel_ownership/channel_ownership_enforced.feature
+++ b/channel_ownership/channel_ownership_enforced.feature
@@ -1,0 +1,51 @@
+Feature Channel ownership enforced - register metadata
+
+  Scenario Outline: Registrator is allowed to register metadata with an unclaimed channel
+    Given a user is Registrator
+    And they select an uclaimed channel
+    When they <Action>
+    Then they are allowed
+
+    Examples:
+      | Action                                |
+      | Register metadata                     |
+      | Edit metadata after file is published |
+
+  Scenario Outline: Claimed channel with allow-all policy
+    Given a user is Registrator
+    And they select a channel claimed by <Channel claimed by>
+    And the selected channel has an allow-all policy on <Action>
+    And they select a Publication Instance Type <Instance Type included in scope> in the channel claim scope
+    When they register metadata
+    Then they are <Permission>
+
+    Examples:
+      | Action                                | Channel claimed by  | Instance Type included in scope | Permission |
+      | Register metadata                     | Own institution     | Included                        | Allowed    |
+      | Register metadata                     | Own institution     | Not included                    | Allowed    |
+      | Register metadata                     | Another institution | Included                        | Allowed    |
+      | Register metadata                     | Another institution | Not included                    | Allowed    |
+      | Edit metadata after file is published | Own institution     | Included                        | Allowed    |
+      | Edit metadata after file is published | Own institution     | Not included                    | Allowed    |
+      | Edit metadata after file is published | Another institution | Included                        | Allowed    |
+      | Edit metadata after file is published | Another institution | Not included                    | Allowed    |
+
+  @ignore(not_part_of_first_delivery)
+  Scenario Outline: Claimed channel with deny-others policy
+    Given a user is Registrator
+    And they select a channel claimed by <Channel claimed by>
+    And the selected channel has a deny-others policy on <Action>
+    And they select a Publication Instance Type <Instance Type included in scope> in the channel claim scope
+    When they register metadata
+    Then they are <Permission>
+
+    Examples:
+      | Action                                | Channel claimed by  | Instance Type included in scope | Permission |
+      | Register metadata                     | Own institution     | Included                        | Allowed    |
+      | Register metadata                     | Own institution     | Not included                    | Allowed    |
+      | Register metadata                     | Another institution | Included                        | Denied     |
+      | Register metadata                     | Another institution | Not included                    | Allowed    |
+      | Edit metadata after file is published | Own institution     | Included                        | Allowed    |
+      | Edit metadata after file is published | Own institution     | Not included                    | Allowed    |
+      | Edit metadata after file is published | Another institution | Included                        | Denied     |
+      | Edit metadata after file is published | Another institution | Not included                    | Allowed    |

--- a/channel_ownership/channel_ownership_enforced.feature
+++ b/channel_ownership/channel_ownership_enforced.feature
@@ -1,6 +1,6 @@
 Feature Channel ownership enforced
 
-  Scenario Outline: Registrator is allowed to register metadata with an unclaimed channel
+  Scenario Outline: An unclaimed channel should not have constraints
     Given a user is Registrator
     And they select an uclaimed channel
     When they <Action>

--- a/channel_ownership/channel_ownership_enforced.feature
+++ b/channel_ownership/channel_ownership_enforced.feature
@@ -1,4 +1,4 @@
-Feature Channel ownership enforced
+Feature: Channel ownership enforced
 
   Scenario Outline: An unclaimed channel should not have constraints
     Given a user is Registrator

--- a/channel_ownership/channel_ownership_enforced.feature
+++ b/channel_ownership/channel_ownership_enforced.feature
@@ -1,4 +1,4 @@
-Feature Channel ownership enforced - register metadata
+Feature Channel ownership enforced
 
   Scenario Outline: Registrator is allowed to register metadata with an unclaimed channel
     Given a user is Registrator

--- a/channel_ownership/channel_ownership_enforced.feature
+++ b/channel_ownership/channel_ownership_enforced.feature
@@ -2,7 +2,7 @@ Feature: Channel ownership enforced
 
   Scenario Outline: An unclaimed channel should not have constraints
     Given a user is Registrator
-    And they select an uclaimed channel
+    And they select an unclaimed channel
     When they <Action>
     Then they are allowed
 

--- a/channel_ownership/tickets.feature
+++ b/channel_ownership/tickets.feature
@@ -5,20 +5,20 @@ Feature: Tickets are sent to curators at the channel owner
     And the channel claim has an allow-all policy for registering metadata
     And publication instance type is part of channel scope
 
-  Scenario:
+  Scenario: Ticket sent to Registrators institution
     Given a Registrator
     And Registrators institution owns the channel
     When metadata is registered
     Then a ticket is sent to curators at Registrators institution
 
-  Scenario:
+  Scenario: Ticket sent to Channel owner, not Registrators institution
     Given a Registrator
     And Registrators institution does not own the channel
     When metadata is registered
     Then a ticket is sent to curators at the channel owner
     And a ticket is not sent to curators at Registrators institution
 
-  Scenario:
+  Scenario: Ticket sent to Channel owner, not contributors institution
     Given a contributor not from the channel owner
     When metadata is registered
     Then a ticket is not sent to curators at contributors institution

--- a/channel_ownership/tickets.feature
+++ b/channel_ownership/tickets.feature
@@ -23,3 +23,8 @@ Feature: Tickets are sent to curators at the channel owner
     When metadata is registered
     Then a ticket is not sent to curators at contributors institution
     And a ticket is sent to curators at the channel owner
+
+    Scenario: Tickets regarding student thesis should only be handled by student thesis curator
+      Given a publication with a Degree-category
+      When a publishing request is sent
+      Then only student thesis curator can approve ticket

--- a/channel_ownership/tickets.feature
+++ b/channel_ownership/tickets.feature
@@ -1,0 +1,25 @@
+Feature: Tickets are sent to curators at the channel owner
+
+  Background:
+    Given metadata registered on a claimed channel
+    And the channel claim has an allow-all policy for registering metadata
+    And publication instance type is part of channel scope
+
+  Scenario:
+    Given a Registrator
+    And Registrators institution owns the channel
+    When metadata is registered
+    Then a ticket is sent to curators at Registrators institution
+
+  Scenario:
+    Given a Registrator
+    And Registrators institution does not own the channel
+    When metadata is registered
+    Then a ticket is sent to curators at the channel owner
+    And a ticket is not sent to curators at Registrators institution
+
+  Scenario:
+    Given a contributor not from the channel owner
+    When metadata is registered
+    Then a ticket is not sent to curators at contributors institution
+    And a ticket is sent to curators at the channel owner


### PR DESCRIPTION
Initial set of Gherkins for channel ownership.

Institutions should be able to claim channels from the Channel Registry as their own. With this claim follows a set of constraints, within a scope, dictating who is allowed to do what with metadata when publishing on the channel. 
In the first delivery, the focus is on claiming the channels, and thus the constraints should be open (which means they are the same as they are today), and the scope should be set to instance types DegreePhd, DegreeMaster, and DegreeBachelor.

In addition, the ticket system has to be tweaked so that when publishing on a claimed channel, it is curators at the channel owner that receives the ticket, not curators at the Registrators institution. 